### PR TITLE
Use a Set for mPressedKeys

### DIFF
--- a/app/src/main/java/io/github/sds100/keymapper/service/MyAccessibilityService.kt
+++ b/app/src/main/java/io/github/sds100/keymapper/service/MyAccessibilityService.kt
@@ -225,7 +225,7 @@ class MyAccessibilityService : AccessibilityService(), IContext, IPerformGlobalA
     /**
      * The keys currently being held down.
      */
-    private val mPressedKeys = mutableListOf<Int>()
+    private val mPressedKeys = mutableSetOf<Int>()
 
     /**
      * When all the keys that map to a specific trigger are pressed, they are put in here.


### PR DESCRIPTION
This ensures that we don't accumulate duplicates in mPressedKeys which
can happen if for some reason we never receive an ACTION_UP when a key
is released.

This happens on my BlackBerry Key2 for example when I press the
"Speed" key in combination with another key while the screen is
off. We receive an ACTION DOWN for KEYCODE_FUNCTION (119) but the
ACTION_UP is never delivered so the 119 gets stuck in mPressedKeys,
effectively breaking all keymapper functionality until the service is
restarted.

This is not a perfect fix since the stale key event remains in
mPressedKeys until the key is pressed and released again but at least
the user has a way of getting out of the stuck state.
