### PR TITLE
Call clearLists on SCREEN_ON

### DIFF
--- a/app/src/main/java/io/github/sds100/keymapper/service/MyAccessibilityService.kt
+++ b/app/src/main/java/io/github/sds100/keymapper/service/MyAccessibilityService.kt
@@ -213,6 +213,9 @@ class MyAccessibilityService : AccessibilityService(), IContext, IPerformGlobalA
                         WidgetsManager.onEvent(ctx, EVENT_RESUME_REMAPS)
                     }
                 }
+                Intent.ACTION_SCREEN_ON -> {
+                    clearLists()
+                }
             }
         }
     }
@@ -291,6 +294,7 @@ class MyAccessibilityService : AccessibilityService(), IContext, IPerformGlobalA
         intentFilter.addAction(ACTION_PAUSE_REMAPPINGS)
         intentFilter.addAction(ACTION_RESUME_REMAPPINGS)
         intentFilter.addAction(ACTION_UPDATE_NOTIFICATION)
+        intentFilter.addAction(Intent.ACTION_SCREEN_ON);
 
         registerReceiver(mBroadcastReceiver, intentFilter)
 


### PR DESCRIPTION
Calling clearLists ensures that we start from a clear state when the
device wakes up. This works around the issue where some devices may
never receive an ACTION_UP for some keys that were pressed while the
screen was off.