### PR TITLE
enable build on mac m1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -161,6 +161,7 @@ dependencies {
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.viewpager2:viewpager2:1.0.0"
     implementation "androidx.datastore:datastore-preferences:1.0.0-beta02"
+    kapt "org.xerial:sqlite-jdbc:3.34.0"
     kapt "androidx.room:room-compiler:$room_version"
 
 //    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'


### PR DESCRIPTION
when building with kotlin on m1 macs, you get some strange kotlin errors
turn out to be related to this:
https://youtrack.jetbrains.com/issue/DBE-12342

forcing the upgrade of sqlite-jdbc will resolve the issue

